### PR TITLE
Corrections for the build and work with ignore plugin, distinct fold for ignored files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,12 @@ tasks {
         gradleVersion = properties("gradleVersion")
     }
 
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions {
+            jvmTarget = "11"
+        }
+    }
+
     patchPluginXml {
         version.set(properties("pluginVersion"))
         sinceBuild.set(properties("pluginSinceBuild"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = ski.chrzanow.foldableprojectview
 pluginName = Foldable ProjectView
 # SemVer format -> https://semver.org
-pluginVersion = 1.1.3
+pluginVersion = 1.1.4-snapshot
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 222
@@ -11,7 +11,7 @@ pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IC
-platformVersion = 222-EAP-SNAPSHOT
+platformVersion = 222.3345.118
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/ski/chrzanow/foldableprojectview/projectView/FoldableProjectViewNode.kt
+++ b/src/main/kotlin/ski/chrzanow/foldableprojectview/projectView/FoldableProjectViewNode.kt
@@ -14,13 +14,14 @@ class FoldableProjectViewNode(
     project: Project,
     settings: ViewSettings?,
     private val children: Set<AbstractTreeNode<*>>,
-) : ProjectViewNode<String>(project, FoldableProjectViewBundle.message("foldableProjectView.name"), settings) {
+    private val foldName: String,
+    private val textAttributes: SimpleTextAttributes,
+) : ProjectViewNode<String>(project, FoldableProjectViewBundle.message("foldableProjectView.name") + foldName, settings) {
 
     override fun update(presentation: PresentationData) {
         presentation.apply {
-            val text = FoldableProjectViewBundle.message("foldableProjectView.node", children.size)
+            val text = FoldableProjectViewBundle.message("foldableProjectView.node", foldName, children.size)
             val toolTip = children.mapNotNull { it.name }.joinToString(", ")
-            val textAttributes = SimpleTextAttributes.GRAY_SMALL_ATTRIBUTES
             addText(ColoredFragment(text, toolTip, textAttributes))
             setIcon(CollapseComponent)
         }

--- a/src/main/kotlin/ski/chrzanow/foldableprojectview/projectView/FoldableTreeStructureProvider.kt
+++ b/src/main/kotlin/ski/chrzanow/foldableprojectview/projectView/FoldableTreeStructureProvider.kt
@@ -27,6 +27,7 @@ class FoldableTreeStructureProvider(project: Project) : TreeStructureProvider {
     private var previewState: FoldableProjectState? = null
     private val projectView = ProjectView.getInstance(project)
     private val state get() = previewState ?: settings
+    private val ignoredStatuses = listOf(FileStatus.IGNORED.id, "IGNORE.PROJECT_VIEW.IGNORED")
 
     init {
         project.messageBus
@@ -92,7 +93,7 @@ class FoldableTreeStructureProvider(project: Project) : TreeStructureProvider {
                     .caseInsensitive()
                     .split(' ')
                     .any { pattern -> patternCache?.createPattern(pattern, Syntax.GLOB)?.matcher(name)?.matches() ?: false }
-            }.or(state.foldIgnoredFiles and(it.fileStatus.equals(FileStatus.IGNORED)))
+            }.or(state.foldIgnoredFiles and(it.fileStatus.id in ignoredStatuses))
         }
 
     private fun String?.caseInsensitive() = when {

--- a/src/main/kotlin/ski/chrzanow/foldableprojectview/projectView/FoldableTreeStructureProvider.kt
+++ b/src/main/kotlin/ski/chrzanow/foldableprojectview/projectView/FoldableTreeStructureProvider.kt
@@ -8,9 +8,7 @@ import com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode
 import com.intellij.ide.projectView.impl.nodes.PsiFileNode
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.components.service
-import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.guessModuleDir
 import com.intellij.openapi.vcs.FileStatus
 import com.intellij.openapi.vcs.FileStatusListener
 import com.intellij.openapi.vcs.FileStatusManager
@@ -57,7 +55,6 @@ class FoldableTreeStructureProvider(project: Project) : TreeStructureProvider {
         return when {
             !state.foldingEnabled -> children
             parent !is PsiDirectoryNode -> children
-            !isModule(parent, project) -> children
             else -> children.match().toSet().let { matched ->
                 when {
                     state.hideAllGroups -> children - matched
@@ -71,11 +68,7 @@ class FoldableTreeStructureProvider(project: Project) : TreeStructureProvider {
     fun withState(state: FoldableProjectState) {
         previewState = state
     }
-
-    private fun isModule(node: PsiDirectoryNode, project: Project) = node.virtualFile?.let {
-        ModuleUtil.findModuleForFile(it, project)?.guessModuleDir() == it
-    } ?: false
-
+    
     private fun MutableCollection<AbstractTreeNode<*>>.match() = this
         .filter {
             when (it) {

--- a/src/main/resources/messages/FoldableProjectView.properties
+++ b/src/main/resources/messages/FoldableProjectView.properties
@@ -1,5 +1,7 @@
 foldableProjectView.name=Foldable ProjectView
-foldableProjectView.node=Folded files: {0}
+foldableProjectView.node=[{0}: {1}]
+foldableProjectView.node.byPattern=folded by pattern
+foldableProjectView.node.byIgnored=ignored
 foldableProjectView.settings.foldingEnabled=Enable folding
 foldableProjectView.settings.foldingEnabled.comment=Fold matching root elements of the project modules in the Project View.
 foldableProjectView.settings.foldDirectories=Fold directories


### PR DESCRIPTION
Hide ignored files functionality In IDEA 2022.2 "ignore" plugin
was removed and recommended way to have the same functionality is now
to install "Foldable ProjectView" plugin.

Add distinct "folder" for the ignored files, to divide it from the folded
by pattern.

Tested on the latest CLion 2022.2